### PR TITLE
Adding Expenses Category Attribute

### DIFF
--- a/src/domain/sanitizers/EntrySanitizer.ts
+++ b/src/domain/sanitizers/EntrySanitizer.ts
@@ -4,26 +4,24 @@ import { BaseEntry } from '../../entity/BaseEntry';
 import { HttpRequestError } from '../../exceptions/HttpRequestError';
 import { validateEntryRules } from '../validators/ValidationRules';
 
-export const entrySanitizer : any = function (req: Request) {
+export const entrySanitizer: any = function (req: Request) {
     return EntrySanitizer.transformRequest(req);
 }
 
-class EntrySanitizer
-{
-    public static transformRequest(req: Request):BaseEntry
-    {
+class EntrySanitizer {
+    public static transformRequest(req: Request): BaseEntry {
         const dto = EntrySanitizer.parseToBaseEntry(req);
         EntrySanitizer.validateFields(dto);
         return EntrySanitizer.getSanitizedObject(dto);
     }
 
-    private static parseToBaseEntry(req: Request):BaseEntry
-    {
+    private static parseToBaseEntry(req: Request): BaseEntry {
         const body = req.body as any;
         return {
             value: body.value,
             description: body.description,
-            type:null
+            type: null,
+            category: body.category
         }
     }
 
@@ -34,17 +32,29 @@ class EntrySanitizer
         }
     }
 
-    private static getSanitizedObject(dto: BaseEntry): BaseEntry
-    {
+    private static getSanitizedObject(dto: BaseEntry): BaseEntry {
         return {
             description: dto.description,
             value: dto.value,
-            type: EntrySanitizer.obtainEntryType(dto.value)
+            type: EntrySanitizer.obtainEntryType(dto.value),
+            category: EntrySanitizer.obtainEntryCategory(dto.value, dto.category)
         }
     }
 
-    private static obtainEntryType(value:number): string
-    {
+    private static obtainEntryType(value: number): string {
         return value >= 0 ? "Receiving" : "Payment";
+    }
+
+    private static obtainEntryCategory(value: number, category: string | null): string {
+        const validCategories = ['Food', 'Health', 'Home', 'Transport', 'Education', 'Leisure', 'Unforseen'];
+        if (value >= 0) {
+            return 'Earnings';
+        }
+
+        if (validCategories.includes(category)) {
+            return category;
+        }
+
+        return 'Other';
     }
 }

--- a/src/entity/BaseEntry.ts
+++ b/src/entity/BaseEntry.ts
@@ -1,6 +1,7 @@
 export class BaseEntry
 {
-    description:string;
-    value:number;
-    type:string;
+    description: string;
+    value: number;
+    type: string;
+    category: string | null;
 }

--- a/src/entity/Entry.ts
+++ b/src/entity/Entry.ts
@@ -20,4 +20,7 @@ export class Entry {
         type: 'timestamp',
       })
     date: Date;
+
+    @Column()
+    category: string;
 }

--- a/tests/EntrySanitizer.test.ts
+++ b/tests/EntrySanitizer.test.ts
@@ -17,6 +17,71 @@ describe('Entry Sanitizer Test Suite', () => {
             expect(result.includes('information')).toBeFalsy()
             expect(result.includes('otherInformation')).toBeFalsy()
         });
+
+        describe('Validates Category alocation', ()=>{
+            describe("Should set 'Income' to Receiving type entries",()=>{
+                it("In case of null or undefined category",()=>{
+                    const req = <Request> {
+                        body: {
+                            description: 'Lorem Ipsum',
+                            value: 5000
+                        }
+                    }
+    
+                    const res = entrySanitizer(req);
+                    expect(res.category).toBe('Earnings')
+                });
+                it("In case of category filled with other any category",()=>{
+                    const req = <Request> {
+                        body: {
+                            description: 'Lorem Ipsum',
+                            value: 5000,
+                            category: 'Other'
+                        }
+                    }
+    
+                    const res = entrySanitizer(req);
+                    expect(res.category).toBe('Earnings')
+                })
+            })
+
+            describe("Should set correct category to Payment type entries",()=>{
+                describe("Should set 'Other' category",()=>{
+                    it('To not entries with not specified values',()=>{
+                        const req = mockRequest;
+                        req.body.value = -10;
+
+                        const res = entrySanitizer(req);
+                        expect(res.category).toBe('Other');
+                    })
+                    it('To invalid category names',()=>{
+                        const req = mockRequest;
+                        req.body.value = -10;
+                        req.body.category = "Lorem Ipsum";
+
+                        const res = entrySanitizer(req);
+                        expect(res.category).toBe('Other');
+                    })
+                })
+
+                describe("Should set a Valid category",()=>{
+                    it('For cases where is passed a valid category as parameter', ()=>{
+                        const validCategories = ['Food', 'Health', 'Home', 'Transport', 'Education', 'Leisure', 'Unforseen'];
+                        
+                        validCategories.forEach( category => {
+                            const req = mockRequest;
+                            req.body.value = -10;
+                            req.body.category = category;
+
+                            const res = entrySanitizer(req);
+                            expect(res.category).toBe(category);
+                        })
+                    })
+                })
+            })
+            
+        })
+
         describe('Validates Value detection and transformation', ()=>{
             const editedMock = mockRequest
             it('Should classify value lesser than 0 as Payment', ()=>{


### PR DESCRIPTION
## Database

> You will need to update the application database to allow
the storage of the category of each expense.

## Categorization of expenses

From now on, every expense must have a **category**, which must be one of the following options:

-   Food
-   Health
-   Home
-   Transport
-   Education
-   Leisure
- Unforeseen
-   Others

You will need to adjust the expense registration endpoint to receive this new information.

### Business rules

- When registering an expense, the category information is **optional**
- If the expense category is not informed, the API should automatically assign the **Other** category to the expense

