### PR TITLE
Month Summary

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,15 @@
+# Path to sources
+#sonar.sources=.
+#sonar.exclusions=
+#sonar.inclusions=
+
+# Path to tests
+#sonar.tests=
+#sonar.test.exclusions=
+#sonar.test.inclusions=
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Exclusions for copy-paste detection
+sonar.cpd.exclusions= src/routes/EntryRoutes.ts

--- a/src/controller/EntryController.ts
+++ b/src/controller/EntryController.ts
@@ -1,89 +1,55 @@
-import { getRepository} from "typeorm";
+import { EntryService } from "../domain/services/EntryService";
 import { NextFunction, Request, Response } from "express";
-import { Entry } from "../entity/Entry";
-import { HttpRequestError } from "../exceptions/HttpRequestError";
-import { validateEntryRules } from "../domain/validators/ValidationRules";
-import { EntrySanitizer } from "../domain/sanitizers/EntrySanitizer";
 
 export class EntryController {
 
-    private entrySanitizer = new EntrySanitizer(validateEntryRules);
-    private entryRepository = getRepository(Entry);
+    private _service = new EntryService();
 
     async all(request: Request, response: Response, next: NextFunction) {
-        const result = await this.entryRepository.find();
-        if(!result) {            
-            throw new HttpRequestError (404, "Nothing Found");
-        }
+        const result = await this._service.getAllEntries();
         response.status(200).json(result);
     }
 
     async receivings(request: Request, response: Response, next: NextFunction) {
-        const result = await this.entryRepository.find({
-            where:{
-                type: "Receiving"
-            }
-        });
-        if(!result) {            
-            throw new HttpRequestError (404, "Nothing Found");
-        }
+        const result = await this._service.getAllReceivings();
         response.status(200).json(result);
     }
 
     async payments(request: Request, response: Response, next: NextFunction) {
-        const result = await this.entryRepository.find({
-            where:{
-                type: "Payment"
-            }
-        });
-        if(!result) {            
-            throw new HttpRequestError (404, "Nothing Found");
-        }
+        const result = await this._service.getAllPayments();
         response.status(200).json(result);
     }
 
     async one(request: Request, response: Response, next: NextFunction) {
-        try{
-            const result = await this.entryRepository.findOne(request.params.id);
-            if(!result) {
-                throw new HttpRequestError (404, "Nothing Found");
-            }
+        try {
+            const result = await this._service.getSpecificEntry(request);
             response.status(200).json(result);
-        } catch(e) {
+        } catch (e) {
             next(e);
         }
     }
 
     async save(request: Request, response: Response, next: NextFunction) {
-        try 
-        {
-            const entry = this.entrySanitizer.transformRequest(request);
-            const result = await this.entryRepository.save(entry);
+        try {
+            const result = await this._service.saveEntry(request);
             response.status(200).json(result);
         }
-        catch (e)
-        {
+        catch (e) {
             next(e);
         }
     }
 
     async update(request: Request, response: Response, next: NextFunction) {
-        try 
-        {
-            const id = request.params.id;
-            const entry = this.entrySanitizer.transformRequest(request);
-            await this.entryRepository.update(id, entry);
-            const result = await this.entryRepository.findOne(id);
+        try {
+            const result = await this._service.updateEntry(request);
             response.status(200).json(result);
         }
-        catch (e)
-        {
+        catch (e) {
             next(e);
         }
     }
 
     async remove(request: Request, response: Response, next: NextFunction) {
-        let entryToRemove = await this.entryRepository.findOne(request.params.id);
-        await this.entryRepository.remove(entryToRemove);
+        await this._service.removeEntry(request);
     }
 }

--- a/src/controller/EntryController.ts
+++ b/src/controller/EntryController.ts
@@ -2,10 +2,12 @@ import { getRepository} from "typeorm";
 import { NextFunction, Request, Response } from "express";
 import { Entry } from "../entity/Entry";
 import { HttpRequestError } from "../exceptions/HttpRequestError";
-import { entrySanitizer } from "../domain/sanitizers/EntrySanitizer";
+import { validateEntryRules } from "../domain/validators/ValidationRules";
+import { EntrySanitizer } from "../domain/sanitizers/EntrySanitizer";
 
 export class EntryController {
 
+    private entrySanitizer = new EntrySanitizer(validateEntryRules);
     private entryRepository = getRepository(Entry);
 
     async all(request: Request, response: Response, next: NextFunction) {
@@ -55,7 +57,7 @@ export class EntryController {
     async save(request: Request, response: Response, next: NextFunction) {
         try 
         {
-            const entry = entrySanitizer(request);
+            const entry = this.entrySanitizer.transformRequest(request);
             const result = await this.entryRepository.save(entry);
             response.status(200).json(result);
         }
@@ -69,7 +71,7 @@ export class EntryController {
         try 
         {
             const id = request.params.id;
-            const entry = entrySanitizer(request);
+            const entry = this.entrySanitizer.transformRequest(request);
             await this.entryRepository.update(id, entry);
             const result = await this.entryRepository.findOne(id);
             response.status(200).json(result);

--- a/src/controller/SummaryController.ts
+++ b/src/controller/SummaryController.ts
@@ -5,9 +5,7 @@ import { validateSummaryRules } from '../domain/validators/ValidationRules';
 
 export class SummaryController {
     
-    
     private entityManager = getManager();
-
 
     async monthSummary(request: Request, response: Response, next: NextFunction) {
 

--- a/src/controller/SummaryController.ts
+++ b/src/controller/SummaryController.ts
@@ -1,0 +1,56 @@
+import { Request, Response, NextFunction } from 'express';
+import { getManager } from "typeorm";
+import { SummarySanitizer } from '../domain/sanitizers/SummarySanitizer';
+import { validateSummaryRules } from '../domain/validators/ValidationRules';
+
+export class SummaryController {
+    
+    
+    private entityManager = getManager();
+
+
+    async monthSummary(request: Request, response: Response, next: NextFunction) {
+
+        try
+        {
+            const sanitizer = new SummarySanitizer(validateSummaryRules);
+            const reqBody = sanitizer.transformRequest(request);
+    
+            const entriesDetail = await this.entityManager.query(this.getEntriesDetail(reqBody.year,reqBody.month));
+            const categoriesDetail = await this.entityManager.query(this.getCategoriesDetail(reqBody.year,reqBody.month));
+    
+            const resBody = 
+            {
+                balance: this.getTotalAmount(entriesDetail),
+                entries: entriesDetail,
+                categories: categoriesDetail
+            }
+    
+            response.status(200).json(resBody);
+        }
+        catch (e)
+        {
+            next(e);
+        }
+        
+    }
+
+    private getEntriesDetail(year:string, month:string) 
+    {
+        return `SELECT e.type as 'type', COUNT(e.id) as 'transactionCount', SUM(e.value) as 'totalAmount' FROM financial_control.entry e WHERE e.date LIKE '%${year}-${month}%' GROUP BY e.type;`
+    }
+    private getCategoriesDetail(year:string, month:string)
+    {
+        return `SELECT e.category as 'type', COUNT(e.id) as 'transactionCount', SUM(e.value) as 'totalAmount' FROM financial_control.entry e WHERE e.date LIKE '%${year}-${month}%' GROUP BY e.category;`;
+    }
+
+    getTotalAmount(entries: Array<any>): number
+    {
+        let total: number;
+        entries.forEach(e => {
+            total =+ e.totalAmount;
+        })
+        return total;
+    }
+
+}

--- a/src/controller/SummaryController.ts
+++ b/src/controller/SummaryController.ts
@@ -48,7 +48,7 @@ export class SummaryController {
     {
         let total: number;
         entries.forEach(e => {
-            total =+ e.totalAmount;
+            total += e.totalAmount;
         })
         return total;
     }

--- a/src/controller/SummaryController.ts
+++ b/src/controller/SummaryController.ts
@@ -44,13 +44,22 @@ export class SummaryController {
         return `SELECT e.category as 'type', COUNT(e.id) as 'transactionCount', SUM(e.value) as 'totalAmount' FROM financial_control.entry e WHERE e.date LIKE '%${year}-${month}%' GROUP BY e.category;`;
     }
 
-    getTotalAmount(entries: Array<any>): number
+    private getTotalAmount(entries: Array<any>): number
     {
-        let total: number;
+        let earnings: number = 0;
+        let expendings: number = 0
         entries.forEach(e => {
-            total += e.totalAmount;
-        })
-        return total;
+            if( e.type == 'Receiving' )
+            {
+                earnings = e.totalAmount;
+            }
+            else
+            {
+                expendings = Math.abs(e.totalAmount);
+            }
+        });
+
+        return earnings - expendings;
     }
 
 }

--- a/src/controller/SummaryController.ts
+++ b/src/controller/SummaryController.ts
@@ -1,63 +1,16 @@
 import { Request, Response, NextFunction } from 'express';
-import { getManager } from "typeorm";
-import { SummarySanitizer } from '../domain/sanitizers/SummarySanitizer';
-import { validateSummaryRules } from '../domain/validators/ValidationRules';
+import { getMonthSummary} from '../domain/services/SummaryService';
 
 export class SummaryController {
-    
-    private entityManager = getManager();
-
     async monthSummary(request: Request, response: Response, next: NextFunction) {
-
         try
         {
-            const sanitizer = new SummarySanitizer(validateSummaryRules);
-            const reqBody = sanitizer.transformRequest(request);
-    
-            const entriesDetail = await this.entityManager.query(this.getEntriesDetail(reqBody.year,reqBody.month));
-            const categoriesDetail = await this.entityManager.query(this.getCategoriesDetail(reqBody.year,reqBody.month));
-    
-            const resBody = 
-            {
-                balance: this.getTotalAmount(entriesDetail),
-                entries: entriesDetail,
-                categories: categoriesDetail
-            }
-    
+            const resBody = await getMonthSummary(request);
             response.status(200).json(resBody);
         }
         catch (e)
         {
             next(e);
-        }
-        
+        }   
     }
-
-    private getEntriesDetail(year:string, month:string) 
-    {
-        return `SELECT e.type as 'type', COUNT(e.id) as 'transactionCount', SUM(e.value) as 'totalAmount' FROM financial_control.entry e WHERE e.date LIKE '%${year}-${month}%' GROUP BY e.type;`
-    }
-    private getCategoriesDetail(year:string, month:string)
-    {
-        return `SELECT e.category as 'type', COUNT(e.id) as 'transactionCount', SUM(e.value) as 'totalAmount' FROM financial_control.entry e WHERE e.date LIKE '%${year}-${month}%' GROUP BY e.category;`;
-    }
-
-    private getTotalAmount(entries: Array<any>): number
-    {
-        let earnings: number = 0;
-        let expendings: number = 0
-        entries.forEach(e => {
-            if( e.type == 'Receiving' )
-            {
-                earnings = e.totalAmount;
-            }
-            else
-            {
-                expendings = Math.abs(e.totalAmount);
-            }
-        });
-
-        return earnings - expendings;
-    }
-
 }

--- a/src/domain/sanitizers/BaseSanitizer.ts
+++ b/src/domain/sanitizers/BaseSanitizer.ts
@@ -1,0 +1,27 @@
+import { Request } from 'express';
+import { Validator } from 'ts.validator.fluent/dist';
+import { HttpRequestError } from '../../exceptions/HttpRequestError';
+
+export abstract class BaseSanitizer<T>
+{
+    constructor(private validationRules: any) {
+    }
+
+    public transformRequest(req: Request): T {
+        const dto = this.parseToBaseType(req);
+        this.validateFields(dto);
+        return this.getSanitizedObject(dto);
+    }
+
+    private validateFields(dto: T): void {
+        const validationResult = new Validator(dto).Validate(this.validationRules);
+        if (!validationResult.IsValid) {
+            throw new HttpRequestError(422, "Invalid parameter.", validationResult.Errors);
+        }
+    }
+
+    protected abstract parseToBaseType(req: Request) : T;
+
+    protected abstract getSanitizedObject(dto): T;
+
+}

--- a/src/domain/sanitizers/EntrySanitizer.ts
+++ b/src/domain/sanitizers/EntrySanitizer.ts
@@ -1,21 +1,14 @@
 import { Request } from 'express';
-import { Validator } from 'ts.validator.fluent/dist';
-import { BaseEntry } from '../../entity/BaseEntry';
-import { HttpRequestError } from '../../exceptions/HttpRequestError';
-import { validateEntryRules } from '../validators/ValidationRules';
+import { BaseEntry } from "../../entity/BaseEntry";
+import { BaseSanitizer } from "./BaseSanitizer";
 
-export const entrySanitizer: any = function (req: Request) {
-    return EntrySanitizer.transformRequest(req);
-}
-
-class EntrySanitizer {
-    public static transformRequest(req: Request): BaseEntry {
-        const dto = EntrySanitizer.parseToBaseEntry(req);
-        EntrySanitizer.validateFields(dto);
-        return EntrySanitizer.getSanitizedObject(dto);
+export class EntrySanitizer extends BaseSanitizer<BaseEntry>
+{
+    constructor(validationRules: any) {
+        super(validationRules);
     }
 
-    private static parseToBaseEntry(req: Request): BaseEntry {
+    protected parseToBaseType(req: Request): BaseEntry {
         const body = req.body as any;
         return {
             value: body.value,
@@ -25,14 +18,7 @@ class EntrySanitizer {
         }
     }
 
-    private static validateFields(entry: BaseEntry) {
-        const validationResult = new Validator(entry).Validate(validateEntryRules);
-        if (!validationResult.IsValid) {
-            throw new HttpRequestError(422, "Invalid parameter.", validationResult.Errors);
-        }
-    }
-
-    private static getSanitizedObject(dto: BaseEntry): BaseEntry {
+    protected getSanitizedObject(dto: any): BaseEntry {
         return {
             description: dto.description,
             value: dto.value,
@@ -57,4 +43,5 @@ class EntrySanitizer {
 
         return 'Other';
     }
+
 }

--- a/src/domain/sanitizers/SummarySanitizer.ts
+++ b/src/domain/sanitizers/SummarySanitizer.ts
@@ -1,0 +1,25 @@
+import { Request } from "express";
+import { BaseSummary } from "../../entity/BaseSummary";
+import { BaseSanitizer } from "./BaseSanitizer";
+
+export class SummarySanitizer extends BaseSanitizer<BaseSummary>
+{
+    constructor(validationRules: any) {
+        super(validationRules);
+    }
+
+    protected parseToBaseType(req: Request) : BaseSummary {
+        const params = req.params;
+        return  {
+            year: params.year,
+            month: params.month
+        }
+    }
+    protected getSanitizedObject(dto: any): BaseSummary {
+        return  {
+            year: dto.year,
+            month: dto.month
+        }
+    }
+    
+}

--- a/src/domain/services/EntryService.ts
+++ b/src/domain/services/EntryService.ts
@@ -1,0 +1,64 @@
+import { Request } from "express";
+import { getRepository } from "typeorm";
+import { EntrySanitizer } from "../sanitizers/EntrySanitizer";
+import { entryRules } from "../validators/ValidationRules";
+import { Entry } from "../../entity/Entry";
+import { HttpRequestError } from "../../exceptions/HttpRequestError";
+
+export class EntryService {
+    private _entrySanitizer = new EntrySanitizer(entryRules);
+    private _entryRepository = getRepository(Entry);
+
+    public async getAllEntries(): Promise<Array<Entry>> {
+        const result = await this._entryRepository.find();
+        if (!result) {
+            throw new HttpRequestError(404, "Nothing Found");
+        }
+        return result;
+    }
+
+    public async getAllReceivings(): Promise<Array<Entry>> {
+        return this.getEntriesWithTypeFilter("Receiving");
+    }
+
+    public async getAllPayments(): Promise<Array<Entry>> {
+        return this.getEntriesWithTypeFilter("Payment");
+    }
+
+    public async getSpecificEntry(request: Request): Promise<Entry> {
+        const result = await this._entryRepository.findOne(request.params.id);
+        if (!result) {
+            throw new HttpRequestError(404, "Nothing Found");
+        }
+        return result;
+    }
+
+    public async saveEntry(request: Request): Promise<Entry> {
+        const entry = this._entrySanitizer.transformRequest(request);
+        return await this._entryRepository.save(entry);
+    }
+
+    public async updateEntry(request: Request): Promise<Entry> {
+        const id = request.params.id;
+        const entry = this._entrySanitizer.transformRequest(request);
+        await this._entryRepository.update(id, entry);
+        return await this._entryRepository.findOne(id);
+    }
+
+    public async removeEntry(request: Request): Promise<void> {
+        let entryToRemove = await this._entryRepository.findOne(request.params.id);
+        await this._entryRepository.remove(entryToRemove);
+    }
+
+    private async getEntriesWithTypeFilter(filter: string): Promise<Array<Entry>> {
+        const result = await this._entryRepository.find({
+            where: {
+                type: filter
+            }
+        });
+        if (!result) {
+            throw new HttpRequestError(404, "Nothing Found");
+        }
+        return result;
+    }
+}

--- a/src/domain/services/SummaryService.ts
+++ b/src/domain/services/SummaryService.ts
@@ -1,0 +1,53 @@
+import { Request } from 'express';
+import { getManager } from "typeorm";
+import { SummarySanitizer } from "../sanitizers/SummarySanitizer";
+import { summaryRules } from "../validators/ValidationRules";
+import { HttpRequestError } from '../../exceptions/HttpRequestError';
+
+export const getMonthSummary = async (req: Request) => new SummaryService().getMonthSummary(req);
+
+class SummaryService {
+    private _entityManager = getManager();
+    private _sanitizer = new SummarySanitizer(summaryRules);
+
+    async getMonthSummary(input: any): Promise<any> {
+        const reqBody = this._sanitizer.transformRequest(input);
+        const entriesDetail = await this._entityManager.query(this.getEntriesDetail(reqBody.year, reqBody.month));
+        const categoriesDetail = await this._entityManager.query(this.getCategoriesDetail(reqBody.year, reqBody.month));
+
+        const response = {
+            balance: this.getTotalAmount(entriesDetail),
+            entries: entriesDetail,
+            categories: categoriesDetail
+        }
+
+        if (!response.balance) {
+            throw new HttpRequestError(404, "No entries found for selected period");
+        }
+
+        return response;
+    }
+
+    private getEntriesDetail(year: string, month: string) {
+        return `SELECT e.type as 'type', COUNT(e.id) as 'transactionCount', SUM(e.value) as 'totalAmount' FROM financial_control.entry e WHERE e.date LIKE '%${year}-${month}%' GROUP BY e.type;`
+    }
+    private getCategoriesDetail(year: string, month: string) {
+        return `SELECT e.category as 'type', COUNT(e.id) as 'transactionCount', SUM(e.value) as 'totalAmount' FROM financial_control.entry e WHERE e.date LIKE '%${year}-${month}%' GROUP BY e.category;`;
+    }
+
+    private getTotalAmount(entries: Array<any>): number {
+        let earnings: number = 0;
+        let expendings: number = 0;
+        
+        entries.forEach(e => {
+            if (e.type == 'Receiving') {
+                earnings = e.totalAmount;
+            }
+            else {
+                expendings = Math.abs(e.totalAmount);
+            }
+        });
+
+        return earnings - expendings;
+    }
+}

--- a/src/domain/validators/ValidationRules.ts
+++ b/src/domain/validators/ValidationRules.ts
@@ -1,11 +1,21 @@
 import { IValidator, ValidationResult } from 'ts.validator.fluent/dist';
 import { BaseEntry } from '../../entity/BaseEntry';
+import { BaseSummary } from '../../entity/BaseSummary';
 
-export const validateEntryRules = (validator: IValidator<BaseEntry>) : ValidationResult => {
+export const validateEntryRules = (validator: IValidator<BaseEntry>): ValidationResult => {
     return validator
         .NotEmpty(e => e.description, "Description cannot be empty")
         .NotNull(e => e.description, "Description cannot be null")
         .NotNull(e => e.value, "Value cannot be null")
         .ToResult();
+}
+
+export const validateSummaryRules = (validator: IValidator<BaseSummary>): ValidationResult => {
+    return validator
+        .Length(s => s.year, 4, 4, "Year should have 4 digits (yyyy)")
+        .Matches(s => s.year, '^[12][0-9]{3}$', "Year must be in between 1000-2999 range")
+        .Length(s => s.month, 2, 2, "Month must have 2 digits (mm)")
+        .Matches(s => s.month, '^(0[1-9]|1[012])$', "Month must be in between 01-12 range")
+        .ToResult()
 }
 

--- a/src/domain/validators/ValidationRules.ts
+++ b/src/domain/validators/ValidationRules.ts
@@ -2,7 +2,7 @@ import { IValidator, ValidationResult } from 'ts.validator.fluent/dist';
 import { BaseEntry } from '../../entity/BaseEntry';
 import { BaseSummary } from '../../entity/BaseSummary';
 
-export const validateEntryRules = (validator: IValidator<BaseEntry>): ValidationResult => {
+export const entryRules = (validator: IValidator<BaseEntry>): ValidationResult => {
     return validator
         .NotEmpty(e => e.description, "Description cannot be empty")
         .NotNull(e => e.description, "Description cannot be null")
@@ -10,7 +10,7 @@ export const validateEntryRules = (validator: IValidator<BaseEntry>): Validation
         .ToResult();
 }
 
-export const validateSummaryRules = (validator: IValidator<BaseSummary>): ValidationResult => {
+export const summaryRules = (validator: IValidator<BaseSummary>): ValidationResult => {
     return validator
         .Length(s => s.year, 4, 4, "Year should have 4 digits (yyyy)")
         .Matches(s => s.year, '^[12][0-9]{3}$', "Year must be in between 1000-2999 range")

--- a/src/entity/BaseSummary.ts
+++ b/src/entity/BaseSummary.ts
@@ -1,0 +1,5 @@
+export class BaseSummary 
+{
+    year: string;
+    month: string;
+}

--- a/src/exceptions/HttpRequestError.ts
+++ b/src/exceptions/HttpRequestError.ts
@@ -8,7 +8,7 @@ BaseError.prototype = new Error();
 
 export class HttpRequestError extends BaseError
 {
-    constructor(public status: number, public message: string, public errors: any[] = null) {
+    constructor(public status: number, public message: string, public errors: any[] | undefined = undefined) {
         super();
     }
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,46 +1,12 @@
-import {EntryController} from "./controller/EntryController";
+import { RouteBuilder } from "./routes/RotuerBuilder";
+import { EntryRoutes } from "./routes/EntryRoutes";
+import { SummaryRoutes } from "./routes/SummaryRoutes";
 
-export const Routes = [
-    {
-        method: "get",
-        route: "/entries",
-        controller: EntryController,
-        action: "all"
-    },
-    {
-        method: "get",
-        route: "/entries/receivings",
-        controller: EntryController,
-        action: "receivings"
-    },
-    {
-        method: "get",
-        route: "/entries/payments",
-        controller: EntryController,
-        action: "payments"
-    },
-    {
-        method: "get",
-        route: "/entries/:id",
-        controller: EntryController,
-        action: "one"
-    }, 
-    {
-        method: "post",
-        route: "/entries",
-        controller: EntryController,
-        action: "save"
-    },
-    {
-        method: "put",
-        route: "/entries/:id",
-        controller: EntryController,
-        action: "update"
-    }, 
-    {
-        method: "delete",
-        route: "/entries/:id",
-        controller: EntryController,
-        action: "remove"
-    }
-];
+export const Routes = 
+    new RouteBuilder()
+        .withControllerRoutes(SummaryRoutes)
+        .withControllerRoutes(EntryRoutes)
+        .getRouter();
+
+
+

--- a/src/routes/EntryRoutes.ts
+++ b/src/routes/EntryRoutes.ts
@@ -1,0 +1,46 @@
+import { EntryController } from '../controller/EntryController';
+
+export const EntryRoutes = [
+    {
+        method: "get",
+        route: "/entries",
+        controller: EntryController,
+        action: "all"
+    },
+    {
+        method: "get",
+        route: "/entries/receivings",
+        controller: EntryController,
+        action: "receivings"
+    },
+    {
+        method: "get",
+        route: "/entries/payments",
+        controller: EntryController,
+        action: "payments"
+    },
+    {
+        method: "get",
+        route: "/entries/:id",
+        controller: EntryController,
+        action: "one"
+    }, 
+    {
+        method: "post",
+        route: "/entries",
+        controller: EntryController,
+        action: "save"
+    },
+    {
+        method: "put",
+        route: "/entries/:id",
+        controller: EntryController,
+        action: "update"
+    }, 
+    {
+        method: "delete",
+        route: "/entries/:id",
+        controller: EntryController,
+        action: "remove"
+    }
+];

--- a/src/routes/IRoute.ts
+++ b/src/routes/IRoute.ts
@@ -1,0 +1,7 @@
+export interface IRoute 
+{
+    method: string,
+    route: string,
+    controller: any,
+    action: string
+}

--- a/src/routes/RotuerBuilder.ts
+++ b/src/routes/RotuerBuilder.ts
@@ -1,0 +1,20 @@
+import { IRoute } from "./IRoute";
+
+export class RouteBuilder
+{
+    private _routes: Array<IRoute> = []
+    
+    public withControllerRoutes(controller: Array<IRoute>): RouteBuilder
+    {
+        controller.forEach(route => {
+            this._routes.push(route);
+        })
+
+        return this;
+    }
+
+    public getRouter(): Array<IRoute>
+    {
+        return this._routes;
+    }
+}

--- a/src/routes/SummaryRoutes.ts
+++ b/src/routes/SummaryRoutes.ts
@@ -1,0 +1,10 @@
+import { SummaryController } from "../controller/SummaryController";
+
+export const SummaryRoutes = [
+    {
+        method: "get",
+        route: "/summary/:year/:month",
+        controller: SummaryController,
+        action: "monthSummary"
+    }
+]

--- a/tests/EntrySanitizer.test.ts
+++ b/tests/EntrySanitizer.test.ts
@@ -1,5 +1,6 @@
 import { Request } from 'express'
-import { entrySanitizer } from '../src/domain/sanitizers/EntrySanitizer';
+import { EntrySanitizer } from '../src/domain/sanitizers/EntrySanitizer';
+import { validateEntryRules } from '../src/domain/validators/ValidationRules';
 
 const mockRequest = <Request>{
     body: {
@@ -9,6 +10,9 @@ const mockRequest = <Request>{
         otherInformation: false
     }
 };
+
+const sanitizer = new EntrySanitizer(validateEntryRules);
+const entrySanitizer = (req) => sanitizer.transformRequest(req);
 
 describe('Entry Sanitizer Test Suite', () => {
     describe('Validates Request Transformation', () => {
@@ -67,7 +71,7 @@ describe('Entry Sanitizer Test Suite', () => {
                 describe("Should set a Valid category",()=>{
                     it('For cases where is passed a valid category as parameter', ()=>{
                         const validCategories = ['Food', 'Health', 'Home', 'Transport', 'Education', 'Leisure', 'Unforseen'];
-                        
+
                         validCategories.forEach( category => {
                             const req = mockRequest;
                             req.body.value = -10;

--- a/tests/EntrySanitizer.test.ts
+++ b/tests/EntrySanitizer.test.ts
@@ -1,6 +1,6 @@
 import { Request } from 'express'
 import { EntrySanitizer } from '../src/domain/sanitizers/EntrySanitizer';
-import { validateEntryRules } from '../src/domain/validators/ValidationRules';
+import { entryRules } from '../src/domain/validators/ValidationRules';
 
 const mockRequest = <Request>{
     body: {
@@ -11,7 +11,7 @@ const mockRequest = <Request>{
     }
 };
 
-const sanitizer = new EntrySanitizer(validateEntryRules);
+const sanitizer = new EntrySanitizer(entryRules);
 const entrySanitizer = (req) => sanitizer.transformRequest(req);
 
 describe('Entry Sanitizer Test Suite', () => {

--- a/tests/EntryValidation.test.ts
+++ b/tests/EntryValidation.test.ts
@@ -1,4 +1,4 @@
-import { validateEntryRules } from "../src/domain/validators/ValidationRules";
+import { entryRules } from "../src/domain/validators/ValidationRules";
 import { Validator } from 'ts.validator.fluent/dist';
 import { BaseEntry } from "../src/entity/BaseEntry"
 
@@ -11,7 +11,7 @@ describe('Entry Validation Test Suite',()=>{
                 value: 0
             };
 
-            const result = new Validator(entry).Validate(validateEntryRules);
+            const result = new Validator(entry).Validate(entryRules);
             const errCount = result.Errors.filter(e => e.Message.includes("Description cannot be empty")).length;
             expect(errCount).toBe(1);
         });
@@ -21,7 +21,7 @@ describe('Entry Validation Test Suite',()=>{
                 description: 'Lorem Ipsum',
             };
 
-            const result = new Validator(entry).Validate(validateEntryRules);
+            const result = new Validator(entry).Validate(entryRules);
             const errCount = result.Errors.filter(e => e.Message.includes("Value cannot be null")).length;
             expect(errCount).toBe(1);
         });
@@ -36,7 +36,7 @@ describe('Entry Validation Test Suite',()=>{
                 value: 10
             };
 
-            const result = new Validator(entry).Validate(validateEntryRules);
+            const result = new Validator(entry).Validate(entryRules);
             expect(result.IsValid).toBeTruthy();
         });
     });

--- a/tests/SummarySanitizer.test.ts
+++ b/tests/SummarySanitizer.test.ts
@@ -1,0 +1,22 @@
+import { Request } from "express";
+import {SummarySanitizer} from "../src/domain/sanitizers/SummarySanitizer"
+import { summaryRules } from "../src/domain/validators/ValidationRules";
+
+const summarySanitizer = (request: Request) => new SummarySanitizer(summaryRules).transformRequest(request);
+describe('Summary Sanitizer Test Suite', () => {
+    const mockRequest = <Request>{
+        params: {
+            year: "1000",
+            month: "10",
+            information: true,
+            otherInformation: false
+        }
+    };
+    describe('Validates Request Transformation', () => {
+        it('Should remove invalid parameters', () => {
+            const result = JSON.stringify(summarySanitizer(mockRequest));
+            expect(result.includes('information')).toBeFalsy()
+            expect(result.includes('otherInformation')).toBeFalsy()
+        });
+    });
+});

--- a/tests/SummaryValidation.test.ts
+++ b/tests/SummaryValidation.test.ts
@@ -1,0 +1,88 @@
+import { Validator } from "ts.validator.fluent/dist";
+import { validateSummaryRules } from "../src/domain/validators/ValidationRules";
+
+describe('Summary Validation Test Suite', () => {
+
+    it('Validate Summary Params', () => {
+        const req =
+        {
+            year: '1993',
+            month: '05'
+        }
+        const result = new Validator(req).Validate(validateSummaryRules);
+        expect(result.IsValid).toBeTruthy()
+    });
+    
+    describe('Validates Month Param', () => {
+        it('Should not allow month that not match regex', () => {
+            const invalidValues = ['0', 'asd', '123'];
+            const req =
+            {
+                year: '2000',
+                month: ''
+            }
+
+            invalidValues.forEach(value => {
+                req.month = value;
+
+                const result = new Validator(req).Validate(validateSummaryRules);
+                const errCount = result.Errors.filter(e => e.Message.includes("Month must be in between 01-12 range")).length;
+                expect(errCount).toBe(1);
+            })
+        });
+
+        it('Should not allow month that doesnt have 2 digits', () => {
+            const invalidValues = ['0', '123'];
+            const req =
+            {
+                year: '2000',
+                month: ''
+            }
+
+            invalidValues.forEach(value => {
+                req.month = value;
+
+                const result = new Validator(req).Validate(validateSummaryRules);
+                const errCount = result.Errors.filter(e => e.Message.includes("Month must have 2 digits (mm)")).length;
+                expect(errCount).toBe(1);
+            })
+        })
+
+    })
+
+    describe('Validates Year Param', () => {
+        it("Should not allow year that not match regex", () => {
+            const invalidValues = ['999', '3000', 'abc'];
+            const req =
+            {
+                month: '05',
+                year: ''
+            }
+
+            invalidValues.forEach(value => {
+                req.year = value;
+
+                const result = new Validator(req).Validate(validateSummaryRules);
+                const errCount = result.Errors.filter(e => e.Message.includes("Year must be in between 1000-2999 range")).length;
+                expect(errCount).toBe(1);
+            })
+        })
+
+        it('Should not allow year that doesnt have 4 digits', () => {
+            const invalidValues = ['12345', '123'];
+            const req =
+            {
+                month: '05',
+                year: ''
+            }
+
+            invalidValues.forEach(value => {
+                req.year = value;
+
+                const result = new Validator(req).Validate(validateSummaryRules);
+                const errCount = result.Errors.filter(e => e.Message.includes("Year should have 4 digits (yyyy)")).length;
+                expect(errCount).toBe(1);
+            })
+        })
+    })
+})

--- a/tests/SummaryValidation.test.ts
+++ b/tests/SummaryValidation.test.ts
@@ -1,5 +1,5 @@
 import { Validator } from "ts.validator.fluent/dist";
-import { validateSummaryRules } from "../src/domain/validators/ValidationRules";
+import { summaryRules } from "../src/domain/validators/ValidationRules";
 
 describe('Summary Validation Test Suite', () => {
 
@@ -9,7 +9,7 @@ describe('Summary Validation Test Suite', () => {
             year: '1993',
             month: '05'
         }
-        const result = new Validator(req).Validate(validateSummaryRules);
+        const result = new Validator(req).Validate(summaryRules);
         expect(result.IsValid).toBeTruthy()
     });
     
@@ -25,7 +25,7 @@ describe('Summary Validation Test Suite', () => {
             invalidValues.forEach(value => {
                 req.month = value;
 
-                const result = new Validator(req).Validate(validateSummaryRules);
+                const result = new Validator(req).Validate(summaryRules);
                 const errCount = result.Errors.filter(e => e.Message.includes("Month must be in between 01-12 range")).length;
                 expect(errCount).toBe(1);
             })
@@ -42,7 +42,7 @@ describe('Summary Validation Test Suite', () => {
             invalidValues.forEach(value => {
                 req.month = value;
 
-                const result = new Validator(req).Validate(validateSummaryRules);
+                const result = new Validator(req).Validate(summaryRules);
                 const errCount = result.Errors.filter(e => e.Message.includes("Month must have 2 digits (mm)")).length;
                 expect(errCount).toBe(1);
             })
@@ -62,7 +62,7 @@ describe('Summary Validation Test Suite', () => {
             invalidValues.forEach(value => {
                 req.year = value;
 
-                const result = new Validator(req).Validate(validateSummaryRules);
+                const result = new Validator(req).Validate(summaryRules);
                 const errCount = result.Errors.filter(e => e.Message.includes("Year must be in between 1000-2999 range")).length;
                 expect(errCount).toBe(1);
             })
@@ -79,7 +79,7 @@ describe('Summary Validation Test Suite', () => {
             invalidValues.forEach(value => {
                 req.year = value;
 
-                const result = new Validator(req).Validate(validateSummaryRules);
+                const result = new Validator(req).Validate(summaryRules);
                 const errCount = result.Errors.filter(e => e.Message.includes("Year should have 4 digits (yyyy)")).length;
                 expect(errCount).toBe(1);
             })


### PR DESCRIPTION
The API must have an endpoint to detail the summary of a given **month**, and it must accept **GET** requests for the URI **/summary/{year}/{month}**.

The summary data must be returned in the response body, in JSON format.

## Business rules

The month summary should contain the following information:

- Total amount of revenue in the month
- Total amount of expenses in the month
- Ending balance for the month
- Total amount spent in the month in each of the categories